### PR TITLE
Check dependencies instead of version, load Async from a temp file, choose header based on header bytes

### DIFF
--- a/Compressor.py
+++ b/Compressor.py
@@ -47,7 +47,12 @@ def get_decompressor_by_header(filename):
                 continue
             print(compression_module['module'])
             header = compression_module['header']
+            len_read   = len(read_header)
             len_header = len(header)
+            min_len = min(len_header,len_read)
+
+            if ( min_len > 0 ) and ( read_header[ 0: min_len] != header[ 0: min_len] ):
+                continue
             while len(read_header) < len_header :
                 read_header.append(ord(f.read(1)))
             if read_header[ 0: len_header ] == header:

--- a/Compressor.py
+++ b/Compressor.py
@@ -1,8 +1,18 @@
 # encoding: utf-8
+'''
+Sublime text de-Compressor
+View compressed files ( gzip, bzip2 ) content in sublime text
+
+'''
+import importlib
+from os.path import basename, join
+from os import remove
+import sys
+from shutil import copyfileobj
+from tempfile import mkdtemp
 
 import sublime
 import sublime_plugin
-
 ''' 
 # header references
 
@@ -12,78 +22,85 @@ import sublime_plugin
 
 '''
 compression_modules = [
-    { 'module' : 'gzip', 'depend' : 'zlib',  'extension' : '.gz', 'header':[0x1F,0x8B] },
+    {'module' : 'gzip', 'depend' : 'zlib',  'extension' : '.gz',  'header':[0x1F, 0x8B]},
     # since build 3114
-    { 'module' : 'bz2',  'depend' : '_bz2',  'extension' : '.bz2', 'header' : [0x42,0x5A] },
+    {'module' : 'bz2',  'depend' : '_bz2',  'extension' : '.bz2', 'header' : [0x42, 0x5A]},
     # future proof 20171031
-    { 'module' : 'lzma', 'depend' : '_lzma', 'extension' : '.xz', 'header' : [0xDF,0x37,0x7A,0x58,0x5A,0x00] } 
+    {'module' : 'lzma', 'depend' : '_lzma', 'extension' : '.xz',  'header' : [0xDF, 0x37, 0x7A, 0x58, 0x5A, 0x00]} 
 ]
 
-import sys
-import importlib
 
-for compression_module in compression_modules :
-    dependendy = compression_module['depend'];
-    if dependendy in sys.builtin_module_names :
-        module    = compression_module['module']
-        extension = compression_module['extension']
-        decompressor = importlib.import_module(module);
+for compression_module in compression_modules:
+    dependendy = compression_module['depend']
+    if dependendy in sys.builtin_module_names:
+        module = compression_module['module']
+
+        decompressor = importlib.import_module(module)
         compression_module['open'] = decompressor.open
 
 def get_decompressor_by_header(filename):
     read_header = []
-    with open(filename,"rb") as f:
-        for compression_module in compression_modules :
+    '''
+    We cannot reliably get character from the buffer to figure out the header 
+    although it would have been nice to do it with View.substr(point)
+
+    Reading a binary file open an hexdump view
+    depending on the `enable_hexadecimal_encoding` setting
+
+    Investigation :
+    sublime.load_settings("Preferences.sublime-settings").get("enable_hexadecimal_encoding")
+    to get current view
+    and have head guess depending on the view 
+    probably too much work for our current needs
+    '''
+    with open(filename, "rb") as f_input:
+        for compression_module in compression_modules:
             suffix = compression_module['extension']
+
             if not 'open' in compression_module:
                 continue
             print(compression_module['module'])
+
             header = compression_module['header']
             len_read   = len(read_header)
             len_header = len(header)
-            min_len = min(len_header,len_read)
 
-            if ( min_len > 0 ) and ( read_header[ 0: min_len] != header[ 0: min_len] ):
+            min_len = min(len_header, len_read)
+
+            if (min_len > 0) and (read_header[0: min_len] != header[0: min_len]):
                 continue
-            while len(read_header) < len_header :
-                read_header.append(ord(f.read(1)))
-            if read_header[ 0: len_header ] == header:
+            while len(read_header) < len_header:
+                read_header.append(ord(f_input.read(1)))
+            if read_header[0: len_header] == header:
                 decompressor = compression_module['open']
                 return suffix, decompressor
     return None, None
 
-class DecompressFileCommand(sublime_plugin.TextCommand):
-    def run(self, edit, filepath=None, suffix=None, decompressor=None):
-        if filepath is None:
-            filepath = self.view.file_name()
-            if not filepath:
-                print("can't find filename for decompression")
-                return
-        suffix, decompressor = get_decompressor_by_header(filepath)
-
-        view = self.view
-        view.set_name(filepath[:-len(suffix)])
-
-        pos = 0
-        with decompressor(filepath) as f:
-            for line in f:
-                # print(type(line), line)
-                pos += view.insert(edit, pos, line.decode('utf-8'))
-
-        view.set_read_only(True)
 
 class OpenCompressedFile(sublime_plugin.EventListener):
 
-    def on_load(self, view):
+    def on_load_async(self, view):
         filepath = view.file_name()
-        # suffix, decompressor = get_decompressor_by_filename(filename)
         suffix, decompressor = get_decompressor_by_header(filepath)
         if suffix and decompressor:
+            window = view.window()
+            view.close()
+
+            file_basename = basename(filepath)[:-len(suffix)]
+            file_temp = join(mkdtemp(), file_basename)
+
             sublime.status_message("opening compressed file: " + filepath)
             print("opening compressed file: " + filepath)
+            print("decompress into: " + file_temp)
 
-            decomp_view = view.window().new_file()
-            view.close()
-            decomp_view.run_command(
-                'decompress_file', {'filepath': filepath }
-            )
+            with decompressor(filepath) as f_input, open(file_temp,"wb") as f_output:
+                copyfileobj(f_input, f_output)
+
+            decomp_view = window.open_file(file_temp)
+            decomp_view.set_status('decompressed','1')
+            decomp_view.set_read_only(True)
+
+    def on_close(self, view):
+        if view.get_status('decompressed'):
+            filepath = view.file_name()
+            remove(filepath)

--- a/Compressor.py
+++ b/Compressor.py
@@ -101,10 +101,11 @@ def decompressInputFile(view):
         print("opening compressed file: " + filepath)
         print("decompress into: " + file_temp)
 
-        #with decompressor(filepath) as f_input:
         f_input = decompressor(filepath)
         with open(file_temp,"wb") as f_output:
             copyfileobj(f_input, f_output)
+        f_input.close()
+        
         decomp_view = window.open_file(file_temp)
         decomp_view.set_status('decompressed','1')
         decomp_view.set_read_only(True)

--- a/Compressor.py
+++ b/Compressor.py
@@ -3,22 +3,40 @@
 import sublime
 import sublime_plugin
 
-import gzip
+''' 
+# header references
 
-compression_formats = {
-    '.gz': gzip.open,
-}
+- [gzip](https://tools.ietf.org/html/rfc1952)
+- [bzip2](https://en.wikipedia.org/wiki/Bzip2#File_format)
+- [xz](https://tukaani.org/xz/format.html)
 
-if sublime.version() >= '3114' :
-    import bz2
-    compression_formats['.bz2'] = bz2.open
+'''
+compression_modules = [
+    { 'module' : 'gzip', 'depend' : 'zlib',  'extension' : '.gz', 'header':'\x1f\x8b' },
+    # since build 3114
+    { 'module' : 'bz2',  'depend' : '_bz2',  'extension' : '.bz2', 'header' : 'BZ'},
+    # future proof 20171031
+    { 'module' : 'lzma', 'depend' : '_lzma', 'extension' : '.xz', 'header' : '\xFD7zXZ\x00'} 
+]
+
+compression_formats = {}
+
+import sys
+import importlib
+
+for compression_module in compression_modules :
+    dependendy = compression_module['depend'];
+    if dependendy in sys.builtin_module_names :
+        module    = compression_module['module']
+        extension = compression_module['extension']
+        decompressor = importlib.import_module(module);
+        compression_formats[extension] = decompressor.open
 
 def get_decompressor_by_filename(filename):
     for suffix, decompressor in compression_formats.items():
         if filename.endswith(suffix):
             return suffix, decompressor
     return None, None
-
 
 class DecompressFileCommand(sublime_plugin.TextCommand):
     def run(self, edit, filename=None, suffix=None, decompressor=None):
@@ -45,7 +63,6 @@ class DecompressFileCommand(sublime_plugin.TextCommand):
                 pos += view.insert(edit, pos, line.decode('utf-8'))
 
         view.set_read_only(True)
-
 
 class OpenCompressedFile(sublime_plugin.EventListener):
     def on_load(self, view):


### PR DESCRIPTION
Fixes
- Check builtin modules dependencies instead of sublime text version for compressor selection

Fixes inspired by @mkuznets
- Load Async
- Create a temporary file for sublime to read 
- read file header for choosing correct decompressor

Tested against
Version 2221 & 3143